### PR TITLE
Updated input component. Feature/MSK21QAS-8-create-input-component

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <sui-button></sui-button>
 
-<sui-input sizeModifier="_small" placeholder="custom placeholder"></sui-input>
+<sui-input size="small" placeholder="custom placeholder"></sui-input>
 <sui-input></sui-input>
-<sui-input sizeModifier="_large"></sui-input>
+<sui-input size="large"></sui-input>

--- a/src/app/library/components/input/input.component.html
+++ b/src/app/library/components/input/input.component.html
@@ -1,1 +1,1 @@
-<input class="input__input-field" [class]="sizeModifier" type="text" [placeholder]="placeholder" />
+<input class="sui-input__input-field" [class]="sizeModifier" type="text" [placeholder]="placeholder" />

--- a/src/app/library/components/input/input.component.less
+++ b/src/app/library/components/input/input.component.less
@@ -1,6 +1,6 @@
 @import 'colors.less';
 
-.input__input-field {
+.sui-input__input-field {
     padding: 4px 11px;
 
     border: 1px solid @lib-grey;
@@ -12,24 +12,30 @@
 
     transition: all 0.3s;
 
+    //.sui-input__input-field:hover
+    //.sui-input__input-field:focus
     &:hover,
     &:focus {
         border-color: lighten(@lib-active-blue, 8%);
     }
 
+    //.sui-input__input-field:focus
     &:focus {
         box-shadow: 0 0 0 2px fade(@lib-active-blue, 20%);
     }
 
+    //.sui-input__input-field::placeholder
     &::placeholder {
         color: darken(@lib-grey, 10%);
     }
 
+    //.sui-input__input-field._size_large
     &._size_large {
         padding: 6.5px 11px;
         font-size: 1.1rem;
     }
 
+    //.sui-input__input-field._size_small
     &._size_small {
         padding: 0 7px;
         font-size: 0.9rem;

--- a/src/app/library/components/input/input.component.less
+++ b/src/app/library/components/input/input.component.less
@@ -25,12 +25,12 @@
         color: darken(@lib-grey, 10%);
     }
 
-    &._large {
+    &._size_large {
         padding: 6.5px 11px;
         font-size: 1.1rem;
     }
 
-    &._small {
+    &._size_small {
         padding: 0 7px;
         font-size: 0.9rem;
     }

--- a/src/app/library/components/input/input.component.ts
+++ b/src/app/library/components/input/input.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { SizeModifierType } from './input.model';
 
 @Component({
@@ -6,10 +6,16 @@ import { SizeModifierType } from './input.model';
     templateUrl: './input.component.html',
     styleUrls: ['./input.component.less'],
 })
-export class InputComponent {
+export class InputComponent implements OnInit {
     @Input()
     placeholder: string = 'input text';
 
     @Input()
-    sizeModifier: SizeModifierType = '';
+    size: SizeModifierType = '';
+
+    sizeModifier: string = '';
+
+    ngOnInit() {
+        this.sizeModifier = this.size ? `_size_${this.size}` : '';
+    }
 }

--- a/src/app/library/components/input/input.model.ts
+++ b/src/app/library/components/input/input.model.ts
@@ -1,1 +1,1 @@
-export type SizeModifierType = '_small' | '_large' | '';
+export type SizeModifierType = 'small' | 'large' | '';


### PR DESCRIPTION
Изменен интерфейс взаимодействия с компонентой. 
Раньше в свойство _sizeModifier_ передавались возможные параметры *'_small'* и *'_large'*, которые являлись CSS модификаторами компоненты. Теперь в свойство _size_ передаются возможные параметры *'small'* и *'large'* (убрано нижнее подчеркивание). Таким образом в проперти компоненты передается не стиль в сыром виде, а указываться состояние.

Также поменял название CSS модификаторов, теперь внутри компоненты они называются *_size_small* и *_size_large*.