### PR TITLE
Feature/MSK21QAS-15-create-board-component

### DIFF
--- a/src/app/app.component.less
+++ b/src/app/app.component.less
@@ -1,0 +1,5 @@
+:host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}

--- a/src/app/components/board/board-item/board-item.component.html
+++ b/src/app/components/board/board-item/board-item.component.html
@@ -1,6 +1,6 @@
 <div
     class="sui-board-item__holder"
-    [ngClass]="{ _interactive: boardSettingsService.isInteractiveMode, _selected: _selected }"
+    [ngClass]="{ _interactive: boardSettingsService.isInteractiveMode, _selected: _isSelected }"
     #holder
 >
     <div class="sui-board-item__place">

--- a/src/app/components/board/board-item/board-item.component.ts
+++ b/src/app/components/board/board-item/board-item.component.ts
@@ -65,6 +65,13 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
         });
     }
 
+    /**
+     * This function adds a library component inside the boardItem.
+     * @template LibraryComponent
+     * @param {Type<LibraryComponent>} libraryComponent - Library component.
+     * @param {IConfigPanelProperty} properties - Default config.
+     * @memberof BoardItemComponent
+     */
     public appendLibComponent<LibraryComponent>(
         libraryComponent: Type<LibraryComponent>,
         properties: IConfigPanelProperty
@@ -78,19 +85,33 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
             //this.libComponentName = this.innerLibComponent.componentType.name;
             // TODO: Fix types here
             this.libComponentName = (this.innerLibComponent.location.nativeElement.localName as string).toLowerCase();
-            this.setLibComponentProps(this.properties);
+
+            for (const key in this.properties) {
+                // TODO: Fix types here
+                this.innerLibComponent.instance[key] = this.properties[key].value;
+            }
         }, 0);
     }
 
-    public deselect(): void {
-        this._isSelected = false;
+    /**
+     * This function updates properties of the current boardItem.
+     * @param {IConfigPanelProperty} config - Updated property.
+     * @memberof BoardItemComponent
+     */
+    public updateLibComponent(config: IConfigPanelProperty): void {
+        for (const key in config) {
+            this.properties[key] = config[key];
+            // TODO: Fix types here
+            this.innerLibComponent.instance[key] = config[key].value;
+        }
     }
 
-    public setLibComponentProps(properties: IConfigPanelProperty): void {
-        for (const key in properties) {
-            // TODO: Fix types here
-            this.innerLibComponent.instance[key] = properties[key].value;
-        }
+    /**
+     * This function deselect current boardItem.
+     * @memberof BoardItemComponent
+     */
+    public deselect(): void {
+        this._isSelected = false;
     }
 
     /**

--- a/src/app/components/board/board-item/board-item.component.ts
+++ b/src/app/components/board/board-item/board-item.component.ts
@@ -84,10 +84,12 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
             this.innerLibComponent = this.viewContainerTarget.createComponent<LibraryComponent>(componentFactory);
             //this.libComponentName = this.innerLibComponent.componentType.name;
             // TODO: Fix types here
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             this.libComponentName = (this.innerLibComponent.location.nativeElement.localName as string).toLowerCase();
 
             for (const key in this.properties) {
                 // TODO: Fix types here
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 this.innerLibComponent.instance[key] = this.properties[key].value;
             }
         }, 0);
@@ -102,6 +104,7 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
         for (const key in config) {
             this.properties[key] = config[key];
             // TODO: Fix types here
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             this.innerLibComponent.instance[key] = config[key].value;
         }
     }

--- a/src/app/components/board/board-item/board-item.component.ts
+++ b/src/app/components/board/board-item/board-item.component.ts
@@ -32,7 +32,7 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
     @ViewChild('holder')
     holder: ElementRef;
 
-    public _selected: boolean = false;
+    public _isSelected: boolean = false;
     public properties: IConfigPanelProperty;
     public libComponentName: string;
 
@@ -42,7 +42,7 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
     @HostListener('dblclick')
     _selectLibComponent(): void {
         if (this.boardSettingsService.isInteractiveMode) return;
-        this._selected = true;
+        this._isSelected = true;
         this.boardConverseService.selectBoardItem(this);
     }
 
@@ -83,7 +83,7 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
     }
 
     public deselect(): void {
-        this._selected = false;
+        this._isSelected = false;
     }
 
     public setLibComponentProps(properties: IConfigPanelProperty): void {

--- a/src/app/components/board/board.component.html
+++ b/src/app/components/board/board.component.html
@@ -35,6 +35,6 @@
 <div
     class="sui-board__move-plug"
     draggable="false"
-    [ngClass]="{ _active: _showDragPanel, _dragging: _dragging }"
+    [ngClass]="{ _active: _isDragPanelShown, _dragging: _isDragging }"
     #fieldMovePlug
 ></div>

--- a/src/app/components/board/board.component.less
+++ b/src/app/components/board/board.component.less
@@ -38,9 +38,9 @@
             transition: transform 0.3s ease-out, height 0.3s ease-out, width 0.3s ease-out;
         }
 
-        //.sui-board__field-showcases
         //Need this to interact with elements
-        &-showcases{
+        //.sui-board__field-showcases
+        &-showcases {
             position: relative;
             z-index: 5;
         }

--- a/src/app/components/board/board.component.less
+++ b/src/app/components/board/board.component.less
@@ -8,7 +8,8 @@
     align-items: center;
 
     height: 100%;
-    min-width: 100%;
+
+    overflow: hidden;
 
     background-color: @sui-gray-3;
 

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -146,6 +146,12 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
     }
     // --------------------------------------------------------------------
 
+    /**
+     * This function sets up a listener of the board converse service that waiting for
+     * a board-item create event.
+     * @private
+     * @memberof BoardComponent
+     */
     private setAddComponentListener(): void {
         const addLibComponent = <LibraryComponent>([libraryComponent, config]: [
             Type<LibraryComponent>,

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -46,8 +46,8 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
         return this.boardSettingsService.isInfiniteBoardMode;
     }
 
-    public _showDragPanel: boolean = false;
-    public _dragging: boolean = false;
+    public _isDragPanelShown: boolean = false;
+    public _isDragging: boolean = false;
 
     private boardItems: Array<any> = [];
     private toUnsubscribe: Array<Subscription> = [];
@@ -197,15 +197,15 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
      */
     private setSpaceHoldListener(): void {
         const unlistenSpaceDown = this.r2.listen('document', 'keydown.space', () => {
-            if (this._showDragPanel) return;
+            if (this._isDragPanelShown) return;
 
-            this._showDragPanel = true;
+            this._isDragPanelShown = true;
 
             const unlistenSpaceUp: () => void = this.r2.listen('document', 'keyup.space', () => {
                 unlistenSpaceUp();
 
-                this._dragging = false;
-                this._showDragPanel = false;
+                this._isDragging = false;
+                this._isDragPanelShown = false;
             });
         });
 
@@ -221,7 +221,7 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
      */
     private setMoveListener(): void {
         const setMetadata: (e: MouseEvent) => void = e => {
-            this._dragging = true;
+            this._isDragging = true;
 
             this.dragMetadata.startPosition.x = e.clientX;
             this.dragMetadata.startPosition.y = e.clientY;
@@ -247,7 +247,7 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
         };
 
         const onMouseUp: () => void = () => {
-            this._dragging = false;
+            this._isDragging = false;
         };
 
         const onMouseDown: (e: MouseEvent) => void = e => {

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -12,6 +12,7 @@ import {
     OnDestroy,
     AfterViewInit,
     HostBinding,
+    HostListener,
 } from '@angular/core';
 import { fromEvent, Observable, Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
@@ -63,6 +64,13 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
             y: 0,
         },
     };
+
+    @HostListener('dblclick', ['$event'])
+    _onDeselect(e: MouseEvent): void {
+        if (e.target === this.field.nativeElement) {
+            this.boardConverseService.selectBoardItem(null);
+        }
+    }
 
     constructor(
         public boardSettingsService: BoardSettingsService,

--- a/src/app/components/header/header.component.less
+++ b/src/app/components/header/header.component.less
@@ -1,17 +1,11 @@
-@import "../../../assets/styles/variables/colors";
-
+@import '../../../assets/styles/variables/colors';
 
 :host {
-    position: fixed;
-    top: 0;
     width: 100%;
     height: 52px;
-    //Change this if you need
-    z-index: 999999999;
 }
 
 .sui-header {
-
     //.sui-header__wrapper
     &__wrapper {
         background: @sui-blue-deep-2;
@@ -33,8 +27,17 @@
     //.sui-header__rainbowBorder
     &__rainbowBorder {
         height: 2px;
-        background: linear-gradient(90deg, hsl(0, 100%, 50%) 29.07%, hsl(29, 100%, 50%) 37.58%, hsl(61, 100%, 50%) 46.37%, hsl(130, 100%, 50%) 56.28%, hsl(205, 100%, 50%) 66.32%, hsl(227, 100%, 50%) 76%, hsl(259, 100%, 50%) 84.21%);
-        animation: rainbowLoad .5s ease-in-out;
+        background: linear-gradient(
+            90deg,
+            hsl(0, 100%, 50%) 29.07%,
+            hsl(29, 100%, 50%) 37.58%,
+            hsl(61, 100%, 50%) 46.37%,
+            hsl(130, 100%, 50%) 56.28%,
+            hsl(205, 100%, 50%) 66.32%,
+            hsl(227, 100%, 50%) 76%,
+            hsl(259, 100%, 50%) 84.21%
+        );
+        animation: rainbowLoad 0.5s ease-in-out;
     }
 
     //.sui-header__navlink
@@ -55,7 +58,7 @@
             margin-top: 5px;
             width: 30px;
             height: 16px;
-            transition: .2s;
+            transition: 0.2s;
         }
     }
 
@@ -120,7 +123,7 @@
         //.sui-header__navigation-btnZoom
         &-btnZoom {
             fill: @sui-white;
-            transition: .2s;
+            transition: 0.2s;
             pointer-events: all;
         }
 
@@ -151,7 +154,7 @@
             &::placeholder {
                 color: @sui-white;
                 font-size: 12px;
-                opacity: .8;
+                opacity: 0.8;
             }
         }
 

--- a/src/app/components/wrapper/wrapper.component.less
+++ b/src/app/components/wrapper/wrapper.component.less
@@ -1,18 +1,22 @@
 @import '/src/assets/styles/variables/colors.less';
 
 :host {
-    position: relative;
+    flex: 1;
+
     display: flex;
-    margin-top: 60px; //Compensise header height
-    //TODO: delete height from :host when a main layout inside the app.component will be done.
-    height: calc(~'100vh - 18px');
+    position: relative;
+
     overflow: hidden;
 }
 
 .sui-wrapper {
+    &__board {
+        flex: 1;
+    }
+
     &__config-panel {
         width: 300px;
-        height: 100vh;        
+        height: 100vh;
 
         position: absolute;
         right: 0;

--- a/src/app/core/services/board-converse.service.ts
+++ b/src/app/core/services/board-converse.service.ts
@@ -61,7 +61,7 @@ export class BoardConverseService {
     public setConfigPanelListener(): Subscription {
         return this.configDataService.saveConfigData$.subscribe((properties: IConfigPanelProperty) => {
             if (!this.selectedBoardItem) return;
-            this.selectedBoardItem.setLibComponentProps(properties);
+            this.selectedBoardItem.updateLibComponent(properties);
         });
     }
 }

--- a/src/app/core/services/board-converse.service.ts
+++ b/src/app/core/services/board-converse.service.ts
@@ -25,6 +25,13 @@ export class BoardConverseService {
         this.addLibraryComponent$.next([libraryComponent, properties]);
     }
 
+    /**
+     * This function is used when user selects boardItem component.
+     * It sends config of the current boardItem to the config-data service.
+     * @param {(BoardItemComponent | null)} selectedBoardItem - Selected component.
+     * @returns  {void}
+     * @memberof BoardConverseService
+     */
     public selectBoardItem(selectedBoardItem: BoardItemComponent | null): void {
         if (this.selectedBoardItem === selectedBoardItem) return;
 
@@ -46,6 +53,11 @@ export class BoardConverseService {
         });
     }
 
+    /**
+     * This function sets up a listener of an update event from the config-data service.
+     * @returns  {Subscription}
+     * @memberof BoardConverseService
+     */
     public setConfigPanelListener(): Subscription {
         return this.configDataService.saveConfigData$.subscribe((properties: IConfigPanelProperty) => {
             if (!this.selectedBoardItem) return;

--- a/src/app/core/services/board-settings.service.ts
+++ b/src/app/core/services/board-settings.service.ts
@@ -20,7 +20,6 @@ export class BoardSettingsService {
     private heightState: number = 650;
     private widthState: number = 1080;
     private boardElement: HTMLElement;
-    private boardMargin: number = 400;
     private isInteractiveModeState: boolean = false;
 
     public isInfiniteBoardMode: boolean = false; // Mode that allows to use all visible space as a board.
@@ -171,7 +170,7 @@ export class BoardSettingsService {
     private normalizeScale(): void {
         if (!this.boardElement) return;
 
-        const computedWidthMinScale: number = (this.boardElement.offsetWidth - this.boardMargin) / this.width;
+        const computedWidthMinScale: number = this.boardElement.offsetWidth / this.width;
         const computedHeightMinScale: number = this.boardElement.offsetHeight / this.height;
 
         const computedMinScale = Math.floor(Math.min(computedHeightMinScale, computedWidthMinScale) * 100) / 100;

--- a/src/app/core/services/board-settings.service.ts
+++ b/src/app/core/services/board-settings.service.ts
@@ -36,6 +36,7 @@ export class BoardSettingsService {
     }
 
     public setScale(value: number): void {
+        if (typeof value != 'number' || isNaN(value)) return;
         this.scaleState = value;
         this.updateTransformStyle();
     }

--- a/src/assets/styles/common/common.less
+++ b/src/assets/styles/common/common.less
@@ -1,3 +1,11 @@
+:root {
+    height: 100vh;
+}
+
+body {
+    height: 100%;
+}
+
 * {
     box-sizing: border-box;
     &:before,
@@ -23,3 +31,4 @@ li {
 p {
     margin: 0;
 }
+


### PR DESCRIPTION
1. Поправил имена булевых переменных.
2. Добавил анимацию появления доски. Такое решение не мешает, если доска полностью помещается в поле при загрузке страницы, но маскирует и сглаживает анимацию изменения скейла при загрузке в случае, когда доска полностью не помещается.
3. Написал jsdoc.
4. Метод, обновляющий компоненту библиотеки внутри **board-item**, теперь перезаписывает только измененные поля.
5. Добавил деселект на двойной клик по пустому месту на доске.
6. В местах, помеченных TODO, где линтер жалуется на типы, добавил _eslint-disable-next-line_.
7. Поправил высоту рута, боди, приложения и враппера. Убрал фиксированное расположение хедера. Пофиксил баг, когда поле накладывалось поверх боковых панелей. Убрал "маржин" для поля, заставлявший автоматический скейл срабатывать раньше.
8. Поправил баг, о котором писал в телеграмме. Теперь при возвращении на страницу, на которой значение _scale_ было не равно нулю, не появляется _NaN_.