### PR TITLE
Z-index logic release. Feature/MSK21QAS-15-create-board-component

### DIFF
--- a/src/app/components/board/board-item/board-item.component.ts
+++ b/src/app/components/board/board-item/board-item.component.ts
@@ -19,6 +19,7 @@ import { Subscription } from 'rxjs';
 
 import { BoardSettingsService } from '@services/board-settings.service';
 import { BoardConverseService } from '@services/board-converse.service';
+import { ZIndexService } from '@services/z-index.service';
 
 import { componentModels } from '@models/config-panel.model';
 import { IDragMetadata } from '@models/board.model';
@@ -74,6 +75,7 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
     constructor(
         public boardSettingsService: BoardSettingsService,
         public boardConverseService: BoardConverseService,
+        private zIndexService: ZIndexService,
         private componentFactoryResolver: ComponentFactoryResolver,
         private boardItem: ElementRef,
         private r2: Renderer2,
@@ -94,6 +96,8 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
+        this.zIndexService.deleteItem(this);
+
         this.toUnlisten.forEach(unlistener => {
             unlistener();
         });

--- a/src/app/components/board/board-item/board-item.component.ts
+++ b/src/app/components/board/board-item/board-item.component.ts
@@ -93,10 +93,11 @@ export class BoardItemComponent implements AfterViewInit, OnDestroy {
 
     ngAfterViewInit(): void {
         this.setMoveListener();
+        this.zIndexService.addNewItem(this);
     }
 
     ngOnDestroy(): void {
-        this.zIndexService.deleteItem(this);
+        this.zIndexService.removeItem(this);
 
         this.toUnlisten.forEach(unlistener => {
             unlistener();

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -19,7 +19,6 @@ import { filter, map } from 'rxjs/operators';
 
 import { BoardSettingsService } from '@services/board-settings.service';
 import { BoardConverseService } from '@services/board-converse.service';
-import { ZIndexService } from '@services/z-index.service';
 
 import { BoardItemComponent } from './board-item/board-item.component';
 import { ContextMenuComponent } from './context-menu/context-menu.component';
@@ -77,7 +76,6 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
     constructor(
         public boardSettingsService: BoardSettingsService,
         public boardConverseService: BoardConverseService,
-        public zIndexService: ZIndexService,
         public boardElement: ElementRef,
         private componentFactoryResolver: ComponentFactoryResolver,
         private r2: Renderer2,
@@ -176,7 +174,6 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
             boardItem.instance.appendLibComponent(libraryComponent);
 
             this.boardItems.push(boardItem);
-            this.zIndexService.addNewItem(boardItem.instance);
         };
 
         this.toUnsubscribe.add(this.boardConverseService.addLibraryComponent$.subscribe(addLibComponent));

--- a/src/app/components/board/board.component.ts
+++ b/src/app/components/board/board.component.ts
@@ -19,6 +19,7 @@ import { filter, map } from 'rxjs/operators';
 
 import { BoardSettingsService } from '@services/board-settings.service';
 import { BoardConverseService } from '@services/board-converse.service';
+import { ZIndexService } from '@services/z-index.service';
 
 import { BoardItemComponent } from './board-item/board-item.component';
 import { ContextMenuComponent } from './context-menu/context-menu.component';
@@ -76,6 +77,7 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
     constructor(
         public boardSettingsService: BoardSettingsService,
         public boardConverseService: BoardConverseService,
+        public zIndexService: ZIndexService,
         public boardElement: ElementRef,
         private componentFactoryResolver: ComponentFactoryResolver,
         private r2: Renderer2,
@@ -174,6 +176,7 @@ export class BoardComponent implements AfterViewInit, OnDestroy {
             boardItem.instance.appendLibComponent(libraryComponent);
 
             this.boardItems.push(boardItem);
+            this.zIndexService.addNewItem(boardItem.instance);
         };
 
         this.toUnsubscribe.add(this.boardConverseService.addLibraryComponent$.subscribe(addLibComponent));

--- a/src/app/components/board/context-menu/context-menu.component.html
+++ b/src/app/components/board/context-menu/context-menu.component.html
@@ -1,4 +1,5 @@
 <div class="sui-context-menu__frame" [style.left]="left" [style.top]="top">
+    <div>Layer: {{ _componentsLayer }}</div>
     <button (click)="_goUp()" class="sui-context-menu__button">+1</button>
     <button (click)="_goDown()" class="sui-context-menu__button">-1</button>
     <button (click)="_delete()" class="sui-context-menu__button">Delete</button>

--- a/src/app/components/board/context-menu/context-menu.component.less
+++ b/src/app/components/board/context-menu/context-menu.component.less
@@ -17,7 +17,7 @@
     &__button {
         display: block;
         height: 20px;
-        width: 80px;
+        width: 160px;
 
         border: 1px solid black;
     }

--- a/src/app/components/board/context-menu/context-menu.component.ts
+++ b/src/app/components/board/context-menu/context-menu.component.ts
@@ -1,6 +1,7 @@
-import { Component, HostListener } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 
 import { BoardConverseService } from '@services/board-converse.service';
+import { ZIndexService } from '@services/z-index.service';
 
 import { BoardItemComponent } from '@components/board/board-item/board-item.component';
 
@@ -9,17 +10,23 @@ import { BoardItemComponent } from '@components/board/board-item/board-item.comp
     templateUrl: './context-menu.component.html',
     styleUrls: ['./context-menu.component.less'],
 })
-export class ContextMenuComponent {
+export class ContextMenuComponent implements OnInit {
     public top: string;
     public left: string;
     public boardItem: BoardItemComponent;
+
+    public _componentsLayer: string;
 
     @HostListener('contextmenu', ['$event'])
     _onCOntextMenu(e: MouseEvent): void {
         e.preventDefault();
     }
 
-    constructor(public boardConverseService: BoardConverseService) {}
+    constructor(public boardConverseService: BoardConverseService, public zIndexService: ZIndexService) {}
+
+    ngOnInit(): void {
+        this._componentsLayer = this.zIndexService.getComponentsLayer(this.boardItem);
+    }
 
     /**
      * This function increase z-index of the board-item component.
@@ -27,7 +34,7 @@ export class ContextMenuComponent {
      */
     public _goUp(): void {
         if (this.boardItem) {
-            this.boardItem.zIndexShift += 1;
+            this.zIndexService.moveItem(this.boardItem, 1);
         }
     }
 
@@ -37,7 +44,7 @@ export class ContextMenuComponent {
      */
     public _goDown(): void {
         if (this.boardItem) {
-            this.boardItem.zIndexShift -= 1;
+            this.zIndexService.moveItem(this.boardItem, -1);
         }
     }
 

--- a/src/app/core/services/z-index.service.ts
+++ b/src/app/core/services/z-index.service.ts
@@ -10,16 +10,32 @@ import { ZIndexObj, Layer } from '@models/z-index.model';
 export class ZIndexService {
     private zIndexState: ZIndexObj = { 0: [] };
 
+    /**
+     * This function returns a current layer of the board-item component.
+     * @param {BoardItemComponent} boardItem - The board-item which index we are looking for.
+     * @returns  {string} - The layer the component is currently on. 'Default' if it's on 0. Numeric if it's somewhere else.
+     * @memberof ZIndexService
+     */
     public getComponentsLayer(boardItem: BoardItemComponent): string {
         if (boardItem.zIndexShift === 0) return 'default';
         return boardItem.zIndexShift.toString();
     }
 
+    /**
+     * This function registers a new component on 0 (default) layer.
+     * @param {BoardItemComponent} boardItem - The component is been just created.
+     * @memberof ZIndexService
+     */
     public addNewItem(boardItem: BoardItemComponent): void {
         this.addItemToLayer(0, boardItem);
     }
 
-    public deleteItem(boardItem: BoardItemComponent): void {
+    /**
+     * Remove a component from z-index layers when it has deleted.
+     * @param {BoardItemComponent} boardItem - The board-item component to remove.
+     * @memberof ZIndexService
+     */
+    public removeItem(boardItem: BoardItemComponent): void {
         const currentLevel: number = boardItem.zIndexShift;
 
         this.zIndexState[currentLevel] = this.zIndexState[currentLevel].filter(item => {
@@ -31,9 +47,15 @@ export class ZIndexService {
             this.deleteLayer(currentLevel);
         }
 
-        this.clearLayers();
+        this.shakeLayers();
     }
 
+    /**
+     * This function moves a component on a different z-index level.
+     * @param {BoardItemComponent} boardItem - A board-item component to move.
+     * @param {number} shiftStep - A difference with current level. Pass 1 for invrease. Pass -1 for decrease.
+     * @memberof ZIndexService
+     */
     public moveItem(boardItem: BoardItemComponent, shiftStep: number): void {
         const currentLevel: number = boardItem.zIndexShift;
 
@@ -49,10 +71,16 @@ export class ZIndexService {
             this.deleteLayer(currentLevel);
         }
 
-        this.clearLayers();
+        this.shakeLayers();
     }
 
-    private clearLayers(): void {
+    /**
+     * This function removes empty spaces between layers indexes. For example we have [-2, 0, 2, 4, 5, 7] layers.
+     * This function shakes this array and squashes layers together so it will be like this [-1, 0, 1, 2, 3, 4].
+     * @private
+     * @memberof ZIndexService
+     */
+    private shakeLayers(): void {
         const strings: Array<string> = Object.keys(this.zIndexState)
             .sort((a, b) => {
                 return +a - +b;
@@ -67,11 +95,19 @@ export class ZIndexService {
         const positiveDegreeAxis: Array<number> =
             strings[1].length === 0 ? [] : strings[1].split(' ').map((s: string) => +s);
 
-        this.shakeLayers(positiveDegreeAxis, 1);
-        this.shakeLayers(negativeDegreeAxis, -1);
+        this.shakeHalfAxis(positiveDegreeAxis, 1);
+        this.shakeHalfAxis(negativeDegreeAxis, -1);
     }
 
-    private shakeLayers(layersAxis: Array<number>, direction: number = 1): void {
+    /**
+     * This function is a part of shakeLayers logic. It takes all negative or all positive layers indexes and removes
+     * empty spaces between.
+     * @private
+     * @param {Array<number>} layersAxis - An array of existing layers indexes.
+     * @param {number} [direction=1] - A key that indicates if it positive or negative part of the zIndexState.
+     * @memberof ZIndexService
+     */
+    private shakeHalfAxis(layersAxis: Array<number>, direction: number = 1): void {
         for (let i = 0; i < layersAxis.length; i++) {
             const bubble: Layer = this.zIndexState[layersAxis[i]];
             this.deleteLayer(layersAxis[i]);
@@ -83,6 +119,13 @@ export class ZIndexService {
         }
     }
 
+    /**
+     * This function assigns a board-item to a new layer.
+     * @private
+     * @param {number} num - A layer index.
+     * @param {BoardItemComponent} boardItem - A board-item to move.
+     * @memberof ZIndexService
+     */
     private addItemToLayer(num: number, boardItem: BoardItemComponent): void {
         if (!this.zIndexState[num]) {
             this.zIndexState[num] = [];
@@ -90,6 +133,12 @@ export class ZIndexService {
         this.zIndexState[num].push(boardItem);
     }
 
+    /**
+     * This function deletes a layer on the zIndexState.
+     * @private
+     * @param {number} num - An index of the layer to remove.
+     * @memberof ZIndexService
+     */
     private deleteLayer(num: number): void {
         if (num != 0) delete this.zIndexState[num];
     }

--- a/src/app/core/services/z-index.service.ts
+++ b/src/app/core/services/z-index.service.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@angular/core';
+
+import { BoardItemComponent } from '@components/board/board-item/board-item.component';
+
+import { ZIndexObj, Layer } from '@models/z-index.model';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class ZIndexService {
+    private zIndexState: ZIndexObj = { 0: [] };
+
+    public getComponentsLayer(boardItem: BoardItemComponent): string {
+        if (boardItem.zIndexShift === 0) return 'default';
+        return boardItem.zIndexShift.toString();
+    }
+
+    public addNewItem(boardItem: BoardItemComponent): void {
+        this.addItemToLayer(0, boardItem);
+    }
+
+    public deleteItem(boardItem: BoardItemComponent): void {
+        const currentLevel: number = boardItem.zIndexShift;
+
+        this.zIndexState[currentLevel] = this.zIndexState[currentLevel].filter(item => {
+            return item != boardItem;
+        });
+
+        // Delete layer if its empty but not 0 level.
+        if (this.zIndexState[currentLevel].length === 0) {
+            this.deleteLayer(currentLevel);
+        }
+
+        this.clearLayers();
+    }
+
+    public moveItem(boardItem: BoardItemComponent, shiftStep: number): void {
+        const currentLevel: number = boardItem.zIndexShift;
+
+        this.zIndexState[currentLevel] = this.zIndexState[currentLevel].filter(item => {
+            return item != boardItem;
+        });
+
+        boardItem.zIndexShift += shiftStep;
+        this.addItemToLayer(boardItem.zIndexShift, boardItem);
+
+        // Delete layer if its empty but not 0 level.
+        if (this.zIndexState[currentLevel].length === 0) {
+            this.deleteLayer(currentLevel);
+        }
+
+        this.clearLayers();
+    }
+
+    private clearLayers(): void {
+        const strings: Array<string> = Object.keys(this.zIndexState)
+            .sort((a, b) => {
+                return +a - +b;
+            })
+            .join(' ')
+            .split('0')
+            .map((s: string) => s.trim());
+
+        //prettier-ignore
+        const negativeDegreeAxis: Array<number> =
+            strings[0].length === 0 ? [] : strings[0].split(' ').map((s: string) => +s).reverse();
+        const positiveDegreeAxis: Array<number> =
+            strings[1].length === 0 ? [] : strings[1].split(' ').map((s: string) => +s);
+
+        this.shakeLayers(positiveDegreeAxis, 1);
+        this.shakeLayers(negativeDegreeAxis, -1);
+    }
+
+    private shakeLayers(layersAxis: Array<number>, direction: number = 1): void {
+        for (let i = 0; i < layersAxis.length; i++) {
+            const bubble: Layer = this.zIndexState[layersAxis[i]];
+            this.deleteLayer(layersAxis[i]);
+            this.zIndexState[(i + 1) * direction] = bubble;
+
+            bubble.forEach(boardItem => {
+                boardItem.zIndexShift = (i + 1) * direction;
+            });
+        }
+    }
+
+    private addItemToLayer(num: number, boardItem: BoardItemComponent): void {
+        if (!this.zIndexState[num]) {
+            this.zIndexState[num] = [];
+        }
+        this.zIndexState[num].push(boardItem);
+    }
+
+    private deleteLayer(num: number): void {
+        if (num != 0) delete this.zIndexState[num];
+    }
+}

--- a/src/app/models/z-index.model.ts
+++ b/src/app/models/z-index.model.ts
@@ -1,0 +1,7 @@
+import { BoardItemComponent } from '@components/board/board-item/board-item.component';
+
+export type Layer = Array<BoardItemComponent>;
+
+export interface ZIndexObj {
+    [key: number]: Layer;
+}


### PR DESCRIPTION
Сделана логика работы с z-index уровнями. 
Компонента может находиться на дефолтном (нулевом) уровне, выше дефолтного уровня или ниже дефолтного уровня. В последних двух случаях она располагается на пронумерованных слоях. Пронумерованные слои с компонентами расположены один за другим и не могут быть пустыми. Таким образом, при попытке много раз повысить или понизить z-index, компонента не поднимется выше или ниже того значения, когда дальнейшая прибавка в z-index'е не оказывает видимых изменений.